### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 SLDAP3
 ======
 
-.. image:: https://pypip.in/version/sldap3/badge.svg
+.. image:: https://img.shields.io/pypi/v/sldap3.svg
     :target: https://pypi.python.org/pypi/sldap3/
     :alt: Latest Version
 
@@ -9,7 +9,7 @@ SLDAP3
     :target: https://travis-ci.org/cannatag/sldap3
     :alt: TRAVIS-CI build status for master branch
 
-.. image:: https://pypip.in/license/sldap3/badge.svg
+.. image:: https://img.shields.io/pypi/l/sldap3.svg
     :target: https://pypi.python.org/pypi/sldap3/
     :alt: License
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20sldap3))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `sldap3`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.